### PR TITLE
ci: fix CI failures on Dependabot PRs + migrate artifact actions to v4

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -22,7 +22,7 @@ jobs:
           runTests: false
           build: npm run build
       - name: Save Build Folder
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: build
           if-no-files-found: error
@@ -43,7 +43,7 @@ jobs:
       - name: Jests Tests
         run: npm run jest:coverage
       - name: Save Coverage Folder
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: coverage-jest
           if-no-files-found: error
@@ -59,7 +59,7 @@ jobs:
       - name: Code Checkout
         uses: actions/checkout@v4
       - name: Download Build Folder
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v8.0.1
         with:
           name: build
       - name: Setup Node
@@ -80,9 +80,9 @@ jobs:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Save Coverage Folder
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7.0.1
         with:
-          name: coverage-ct
+          name: coverage-ct-${{ matrix.containers }}
           if-no-files-found: ignore
           path: coverage/
   cypress-e2e:
@@ -96,7 +96,7 @@ jobs:
       - name: Code Checkout
         uses: actions/checkout@v4
       - name: Download Build Folder
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v8.0.1
         with:
           name: build
       - name: Setup Node
@@ -118,9 +118,9 @@ jobs:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Save Coverage Folder
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7.0.1
         with:
-          name: coverage-e2e
+          name: coverage-e2e-${{ matrix.containers }}
           if-no-files-found: ignore
           path: coverage/
   code-coverage:
@@ -133,7 +133,14 @@ jobs:
       - name: Code Checkout
         uses: actions/checkout@v4
       - name: Download Coverage Folder
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v8.0.1
+        # v4 forbids duplicate artifact names, so the matrix jobs now upload
+        # per-container artifacts (coverage-ct-*, coverage-e2e-*). Merge them
+        # back into a single coverage/ tree for the merge step below.
+        with:
+          pattern: coverage-*
+          merge-multiple: true
+          path: coverage
       - name: Setup Node
         uses: actions/setup-node@v3
       - name: Merge Coverage Reports

--- a/.github/workflows/cypress-split.yml
+++ b/.github/workflows/cypress-split.yml
@@ -61,7 +61,7 @@ jobs:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload Test Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: cypress-split-results-e2e-${{ strategy.job-index }}
           path: |
@@ -100,7 +100,7 @@ jobs:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload Test Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: cypress-split-results-ct-${{ strategy.job-index }}
           path: |
@@ -122,7 +122,7 @@ jobs:
         uses: cypress-io/github-action@v6
         with:
           runTests: false
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v8.0.1
         with:
           path: split-results
       - name: Display Structure Of Download Files
@@ -149,7 +149,7 @@ jobs:
             --reportDir mochawesome/results \
             --reportFilename index.html
       - name: Upload Report Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: merged-mochawesome-report
           path: mochawesome
@@ -166,7 +166,7 @@ jobs:
         uses: cypress-io/github-action@v6
         with:
           runTests: false
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v8.0.1
         with:
           path: split-results
       - name: Display Structure Of Download Files
@@ -174,7 +174,7 @@ jobs:
       - name: Merge Coverage Reports
         run: npx cc-merge split-results
       - name: Upload Coverage Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: merged-coverage
           path: coverage

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -23,7 +23,7 @@ jobs:
           runTests: false
           build: npm run build
       - name: Save Build Folder
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: build
           if-no-files-found: error
@@ -39,7 +39,7 @@ jobs:
       - name: Code Checkout
         uses: actions/checkout@v4
       - name: Download Build Folder
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v8.0.1
         with:
           name: build
       - name: Setup Node
@@ -72,7 +72,7 @@ jobs:
       - name: Code Checkout
         uses: actions/checkout@v4
       - name: Download Build Folder
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v8.0.1
         with:
           name: build
       - name: Setup Node

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -29,6 +29,8 @@ jobs:
           if-no-files-found: error
           path: dist
   cypress-run-ct:
+    # Dependabot PRs can't access CYPRESS_RECORD_KEY; skip recorded runs.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-22.04
     needs: install
     strategy:
@@ -62,6 +64,8 @@ jobs:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   cypress-run-e2e:
+    # Dependabot PRs can't access CYPRESS_RECORD_KEY; skip recorded runs.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-22.04
     needs: install
     strategy:

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -16,6 +16,9 @@ jobs:
       - name: Install Dependencies & Build
         run: npm ci && npm run build
       - name: Firebase Deploy
+        # Dependabot PRs can't access the Firebase service-account secret, so
+        # only build/validate for them and skip the preview deploy.
+        if: github.actor != 'dependabot[bot]'
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'

--- a/server-cypress.js
+++ b/server-cypress.js
@@ -1,11 +1,20 @@
 const fs = require('fs');
 const path = require('path');
 
+// Dependabot (and other restricted) runs don't receive ENVIRONMENT_FILE.
+// Fall back to the committed template so the build still compiles.
+const environment = process.env.ENVIRONMENT_FILE
+  ? `${process.env.ENVIRONMENT_FILE}`
+  : fs.readFileSync(
+      path.join('src/environments', 'environment.template.ts'),
+      'utf8'
+    );
+
 const filesList = [
   {
     dir: 'src/environments',
     name: 'environment.development.ts',
-    content: `${process.env.ENVIRONMENT_FILE}`
+    content: environment
   },
   {
     dir: 'cypress/fixtures',

--- a/server.js
+++ b/server.js
@@ -4,7 +4,11 @@ const path = require('path');
 const dir = 'src/environments';
 const file = 'environment.ts';
 
-const content = `${process.env.ENVIRONMENT_FILE}`;
+// Dependabot (and other restricted) runs don't receive ENVIRONMENT_FILE.
+// Fall back to the committed template so the build/tests still compile.
+const content = process.env.ENVIRONMENT_FILE
+  ? `${process.env.ENVIRONMENT_FILE}`
+  : fs.readFileSync(path.join(dir, 'environment.template.ts'), 'utf8');
 
 fs.access(dir, fs.constants.F_OK, (err) => {
   if (err) {


### PR DESCRIPTION
## Problem

Every Dependabot PR was failing CI (the "lots of reports" noise), and Cypress was failing on all branches. Three root causes:

1. **`actions/upload-artifact@v3` is force-failed by GitHub** → killed the Cypress workflow on every push.
2. **Empty `ENVIRONMENT_FILE` on restricted runs** → Dependabot can't read Actions secrets, so generated `environment.ts` was empty → `TS2306: not a module` → Jest + Firebase build failed.
3. **Secret-dependent jobs** (Firebase preview deploy, recorded Cypress) can't auth on Dependabot → always failed.

## Changes

- **Bump artifact actions** to `upload-artifact@v7.0.1` / `download-artifact@v8.0.1` in `cypress.yml`, `cypress-split.yml`, `code-coverage.yml`.
- **Env template fallback** in `server.js` / `server-cypress.js`: use committed `environment.template.ts` when `ENVIRONMENT_FILE` is unset, so build/Jest compile on restricted runs.
- **Guard secret-dependent jobs** for Dependabot: skip Firebase deploy step and Cypress recorded run jobs (`github.actor != 'dependabot[bot]'`); build/install still run.
- **code-coverage v4 migration**: matrix jobs now upload unique artifact names (v4 forbids duplicates) and merge back into a single `coverage/` tree on download.

## Notes

- `code-coverage.yml` runs on `develop` push only — the unique-name + merge-multiple change needs a live validation run on `develop`.
- This does **not** clear the 28 open Dependabot alerts; it unblocks the PRs that fix them. Remaining gap: add `ENVIRONMENT_FILE` + `FIREBASE_SERVICE_ACCOUNT_USERSROLE` under Settings → Secrets → **Dependabot** tab if you want preview deploys/recorded runs on those PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)