### PR TITLE
Harden env-file handling and drop unused App Check debug token

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -17,6 +17,7 @@ jobs:
         env:
           ENVIRONMENT_FILE: ${{ secrets.ENVIRONMENT_FILE }}
           ACCOUNTS_FILE: ${{ secrets.ACCOUNTS_FILE }}
+          ALLOW_ENV_TEMPLATE_FALLBACK: 'true'
       - name: Cypress Install
         uses: cypress-io/github-action@v6
         with:
@@ -51,6 +52,7 @@ jobs:
         env:
           ENVIRONMENT_FILE: ${{ secrets.ENVIRONMENT_FILE }}
           ACCOUNTS_FILE: ${{ secrets.ACCOUNTS_FILE }}
+          ALLOW_ENV_TEMPLATE_FALLBACK: 'true'
       - name: Cypress Run
         uses: cypress-io/github-action@v6
         with:
@@ -86,6 +88,7 @@ jobs:
         env:
           ENVIRONMENT_FILE: ${{ secrets.ENVIRONMENT_FILE }}
           ACCOUNTS_FILE: ${{ secrets.ACCOUNTS_FILE }}
+          ALLOW_ENV_TEMPLATE_FALLBACK: 'true'
       - name: Cypress Run
         uses: cypress-io/github-action@v6
         with:

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -13,6 +13,9 @@ jobs:
         run: node server.js
         env:
           ENVIRONMENT_FILE: '${{ secrets.ENVIRONMENT_FILE }}'
+          # Dependabot PRs lack the secret; allow the placeholder template so
+          # the build still validates. The deploy step is skipped for them.
+          ALLOW_ENV_TEMPLATE_FALLBACK: 'true'
       - name: Install Dependencies & Build
         run: npm ci && npm run build
       - name: Firebase Deploy

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -15,6 +15,7 @@ jobs:
         run: node server.js
         env:
           ENVIRONMENT_FILE: '${{ secrets.ENVIRONMENT_FILE }}'
+          ALLOW_ENV_TEMPLATE_FALLBACK: 'true'
       - name: Install Dependencies
         run: npm ci
       - name: Jests Tests

--- a/server-cypress.js
+++ b/server-cypress.js
@@ -1,14 +1,24 @@
 const fs = require('fs');
 const path = require('path');
 
-// Dependabot (and other restricted) runs don't receive ENVIRONMENT_FILE.
-// Fall back to the committed template so the build still compiles.
-const environment = process.env.ENVIRONMENT_FILE
-  ? `${process.env.ENVIRONMENT_FILE}`
-  : fs.readFileSync(
-      path.join('src/environments', 'environment.template.ts'),
-      'utf8'
-    );
+// Restricted runs (e.g. Dependabot) don't receive ENVIRONMENT_FILE. Those
+// jobs opt into the placeholder template via ALLOW_ENV_TEMPLATE_FALLBACK so
+// they still compile. Deploy jobs must NOT set it: a missing secret then
+// fails the build loudly instead of silently shipping a blank config.
+let environment;
+if (process.env.ENVIRONMENT_FILE) {
+  environment = `${process.env.ENVIRONMENT_FILE}`;
+} else if (process.env.ALLOW_ENV_TEMPLATE_FALLBACK === 'true') {
+  environment = fs.readFileSync(
+    path.join('src/environments', 'environment.template.ts'),
+    'utf8'
+  );
+} else {
+  console.error(
+    'ENVIRONMENT_FILE is not set and ALLOW_ENV_TEMPLATE_FALLBACK is not enabled'
+  );
+  process.exit(1);
+}
 
 const filesList = [
   {

--- a/server.js
+++ b/server.js
@@ -4,11 +4,21 @@ const path = require('path');
 const dir = 'src/environments';
 const file = 'environment.ts';
 
-// Dependabot (and other restricted) runs don't receive ENVIRONMENT_FILE.
-// Fall back to the committed template so the build/tests still compile.
-const content = process.env.ENVIRONMENT_FILE
-  ? `${process.env.ENVIRONMENT_FILE}`
-  : fs.readFileSync(path.join(dir, 'environment.template.ts'), 'utf8');
+// Restricted runs (e.g. Dependabot) don't receive ENVIRONMENT_FILE. Those
+// jobs opt into the placeholder template via ALLOW_ENV_TEMPLATE_FALLBACK so
+// they still compile. Deploy jobs must NOT set it: a missing secret then
+// fails the build loudly instead of silently shipping a blank config.
+let content;
+if (process.env.ENVIRONMENT_FILE) {
+  content = `${process.env.ENVIRONMENT_FILE}`;
+} else if (process.env.ALLOW_ENV_TEMPLATE_FALLBACK === 'true') {
+  content = fs.readFileSync(path.join(dir, 'environment.template.ts'), 'utf8');
+} else {
+  console.error(
+    'ENVIRONMENT_FILE is not set and ALLOW_ENV_TEMPLATE_FALLBACK is not enabled'
+  );
+  process.exit(1);
+}
 
 fs.access(dir, fs.constants.F_OK, (err) => {
   if (err) {

--- a/src/environments/environment.template.ts
+++ b/src/environments/environment.template.ts
@@ -12,6 +12,5 @@ export const environment = {
   },
   recaptcha: {
     siteKey: ''
-  },
-  appCheckDebugToken: ''
+  }
 };


### PR DESCRIPTION
Follow-ups to #89, surfaced while debugging the production auth outage (App Check enforcement).

## Changes

**1. `chore(config)`: drop unused `appCheckDebugToken` from env template**
The app wires App Check via `ReCaptchaV3Provider` and never reads `appCheckDebugToken`, but the value still shipped in the prod bundle. A debug token bypasses App Check attestation if activated — it shouldn't be in committed config. **The matching `ENVIRONMENT_FILE` secret payload should have the field removed too** (manual, repo settings).

**2. `fix(ci)`: gate env template fallback behind explicit opt-in**
The fallback added in #89 was unconditional: a missing `ENVIRONMENT_FILE` secret would silently fall back to the blank template and **deploy a dead app** (previously the build failed loudly via `TS2306`). Now the fallback requires `ALLOW_ENV_TEMPLATE_FALLBACK=true`, set only in the restricted (Dependabot-reachable) jobs — `jest.yml`, `cypress.yml`, and the `firebase-hosting-pull-request.yml` build. The production merge/deploy workflow leaves it unset, so a missing secret fails the build instead of shipping blank config.

Verified locally: no secret + no flag → `exit 1` (loud); no secret + flag → template; secret set → passthrough.

## Not included (needs your action — production auth outage)
The live outage is **Firebase App Check enforcement on Authentication** rejecting tokens (`401: Firebase App Check token is invalid`), blocking all sign-in methods. That's console/GCP config, not code. Immediate unblock: set Authentication to **Unenforced** in App Check, then fix reCAPTCHA attestation before re-enforcing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)