### PR TITLE
ci: pin live-deploy firebase-tools to 15.22.1 for ADC auth

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -24,7 +24,8 @@ jobs:
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_USERSROLE }}'
           channelId: live
           projectId: usersrole
-          # Pinned: firebase-tools 15.22.x has connection instability (dropped
-          # keep-alive / premature close) that triggers spurious retries and
-          # fails the deploy. Keep in sync with the PR-preview workflow.
-          firebaseToolsVersion: '15.21.0'
+          # Pinned to the last release that authenticates via service-account
+          # ADC for a full `firebase deploy`: 15.21.0 fails this path with
+          # "Failed to authenticate", and 15.22.2 introduced a separate ADC
+          # regression, so 15.22.1 is the working window for the live deploy.
+          firebaseToolsVersion: '15.22.1'


### PR DESCRIPTION
## Why

PR #94's merge fired the live prod deploy, which failed deterministically:

```
Failed to authenticate, have you run firebase login?
```

`firebase-hosting-merge.yml` runs `firebase deploy --only hosting`. On the pinned `firebase-tools@15.21.0` that path fails service-account ADC auth. The PR-preview workflow uses `hosting:channel:deploy`, which authenticates fine on 15.21.0, so it's unchanged.

15.22.2 introduced a separate ADC/WIF regression, so **15.22.1** is the working window for the full deploy path.

## Change

- `firebase-hosting-merge.yml`: `firebaseToolsVersion` 15.21.0 → 15.22.1

Merging re-triggers the live deploy on 15.22.1, updating production (currently serving the pre-merge build — no outage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)