### PR TITLE
ci: track firebase-tools latest for hosting deploys

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -24,9 +24,3 @@ jobs:
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_USERSROLE }}'
           channelId: live
           projectId: usersrole
-          # Pinned: earlier releases fail the service-account token fetch with
-          # "Premature close" on oauth2/v4/token (surfaced as "Failed to
-          # authenticate"). 15.22.3 disabled keep-alive in the auth library to
-          # fix exactly that; 15.22.4 is the first release carrying the fix
-          # that also authenticates cleanly here.
-          firebaseToolsVersion: '15.22.4'

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -24,8 +24,9 @@ jobs:
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_USERSROLE }}'
           channelId: live
           projectId: usersrole
-          # Pinned to the last release that authenticates via service-account
-          # ADC for a full `firebase deploy`: 15.21.0 fails this path with
-          # "Failed to authenticate", and 15.22.2 introduced a separate ADC
-          # regression, so 15.22.1 is the working window for the live deploy.
-          firebaseToolsVersion: '15.22.1'
+          # Pinned: earlier releases fail the service-account token fetch with
+          # "Premature close" on oauth2/v4/token (surfaced as "Failed to
+          # authenticate"). 15.22.3 disabled keep-alive in the auth library to
+          # fix exactly that; 15.22.4 is the first release carrying the fix
+          # that also authenticates cleanly here.
+          firebaseToolsVersion: '15.22.4'

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -27,7 +27,3 @@ jobs:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_USERSROLE }}'
           projectId: usersrole
-          # Pinned: firebase-tools 15.22.x has connection instability (dropped
-          # keep-alive / premature close) that triggers spurious retries, which
-          # then fail the channel deploy with "already exists"/"already active".
-          firebaseToolsVersion: '15.21.0'


### PR DESCRIPTION
## Why

The live-deploy version pins added while fixing PR #94's deploy were chasing a symptom. Root cause of the "Failed to authenticate" on the live deploy was a `Premature close` on the service-account token fetch (`oauth2/v4/token`) — a keep-alive connection bug fixed in firebase-tools 15.22.3. Older pins (15.21.0 / 15.22.1) predate that fix.

## Change

Remove `firebaseToolsVersion` from both hosting workflows so they track the current release (15.22.4+), which carries the keep-alive fix and authenticates cleanly.

Tradeoff: unpinned tracks latest and picks up fixes automatically, at the cost of exposure to future upstream regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)