### PR TITLE
chore: bump version to 5.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "usersrole",
-  "version": "0.0.0",
+  "version": "5.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "usersrole",
-      "version": "0.0.0",
+      "version": "5.0.0",
       "license": "ISC",
       "dependencies": {
         "@angular/animations": "22.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usersrole",
-  "version": "0.0.0",
+  "version": "5.0.0",
   "scripts": {
     "start": "ng serve",
     "build": "ng build",


### PR DESCRIPTION
Bumps `package.json` / `package-lock.json` from `0.0.0` → `5.0.0` ahead of cutting the **v5.0.0** GitHub release.

- Aligns the app version shown on `/about` (`VERSION_INFO.app`) with the release tag.
- Resumes the v-tag line (last release was v4.1.0, Oct 2023) after the Angular 22 zoneless upgrade (#94) and the About page (#97).

Merging redeploys prod so `/about` reflects `5.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)